### PR TITLE
Add option to wildcard saml attributes into headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides a SAML SP authentication proxy for backend web services
   -attribute-header-mappings attribute=header
         Comma separated list of attribute=header pairs mapping SAML IdP response attributes to forwarded request header (env SAML_PROXY_ATTRIBUTE_HEADER_MAPPINGS)
   -attribute-header-wildcard
-    	Maps all SAML into X-SW- headers (env SAML_PROXY_ATTRIBUTE_HEADER_WILDCARD)
+    	Maps all SAML into X-*Saml*- headers (env SAML_PROXY_ATTRIBUTE_HEADER_WILDCARD)
   -authorize-attribute attribute
         Enables authorization and specifies the attribute to check for authorized values (env SAML_PROXY_AUTHORIZE_ATTRIBUTE)
   -authorize-values values

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Provides a SAML SP authentication proxy for backend web services
         If set, allows for IdP initiated authentication flow (env SAML_PROXY_ALLOW_IDP_INITIATED)
   -attribute-header-mappings attribute=header
         Comma separated list of attribute=header pairs mapping SAML IdP response attributes to forwarded request header (env SAML_PROXY_ATTRIBUTE_HEADER_MAPPINGS)
+  -attribute-header-wildcard
+    	Maps all SAML into X-SW- headers (env SAML_PROXY_ATTRIBUTE_HEADER_WILDCARD)
   -authorize-attribute attribute
         Enables authorization and specifies the attribute to check for authorized values (env SAML_PROXY_AUTHORIZE_ATTRIBUTE)
   -authorize-values values

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides a SAML SP authentication proxy for backend web services
   -attribute-header-mappings attribute=header
         Comma separated list of attribute=header pairs mapping SAML IdP response attributes to forwarded request header (env SAML_PROXY_ATTRIBUTE_HEADER_MAPPINGS)
   -attribute-header-wildcard
-    	Maps all SAML into X-*Saml*- headers (env SAML_PROXY_ATTRIBUTE_HEADER_WILDCARD)
+        Maps all SAML attributes with this option as a prefix (env SAML_PROXY_ATTRIBUTE_HEADER_WILDCARD)
   -authorize-attribute attribute
         Enables authorization and specifies the attribute to check for authorized values (env SAML_PROXY_AUTHORIZE_ATTRIBUTE)
   -authorize-values values

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -117,7 +117,7 @@ func (p *proxy) handler(respOutWriter http.ResponseWriter, reqIn *http.Request) 
 	if p.config.AttributeHeaderWildcard == true {
 		for attr, values := range sessionClaims.GetAttributes() {
 			for _, value := range values {
-				reqOut.Header.Add("X-SW-"+attr, value)
+				reqOut.Header.Add("X-*Saml*-"+attr, value)
 			}
 		}
 	}

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/crewjam/saml/samlsp"
-	"github.com/patrickmn/go-cache"
 	"io"
 	"log"
 	"net"
@@ -13,6 +11,9 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/crewjam/saml/samlsp"
+	"github.com/patrickmn/go-cache"
 )
 
 const (
@@ -112,6 +113,15 @@ func (p *proxy) handler(respOutWriter http.ResponseWriter, reqIn *http.Request) 
 			}
 		}
 	}
+
+	if p.config.AttributeHeaderWildcard != nil {
+		for attr, values := range sessionClaims.GetAttributes() {
+			for _, value := range values {
+				reqOut.Header.Add("X-SW-"+attr, value)
+			}
+		}
+	}
+
 	if p.config.NameIdMapping != "" {
 		reqOut.Header.Set(p.config.NameIdMapping,
 			sessionClaims.Subject)

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -114,7 +114,7 @@ func (p *proxy) handler(respOutWriter http.ResponseWriter, reqIn *http.Request) 
 		}
 	}
 
-	if p.config.AttributeHeaderWildcard != nil {
+	if p.config.AttributeHeaderWildcard == true {
 		for attr, values := range sessionClaims.GetAttributes() {
 			for _, value := range values {
 				reqOut.Header.Add("X-SW-"+attr, value)

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -114,10 +114,10 @@ func (p *proxy) handler(respOutWriter http.ResponseWriter, reqIn *http.Request) 
 		}
 	}
 
-	if p.config.AttributeHeaderWildcard == true {
+	if p.config.AttributeHeaderWildcard != "" {
 		for attr, values := range sessionClaims.GetAttributes() {
 			for _, value := range values {
-				reqOut.Header.Add("X-*Saml*-"+attr, value)
+				reqOut.Header.Add(p.config.AttributeHeaderWildcard+attr, value)
 			}
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -31,6 +31,7 @@ type Config struct {
 	SpCertPath              string            `default:"saml-auth-proxy.cert" usage:"The [path] to the X509 public certificate PEM file for this SP"`
 	NameIdMapping           string            `usage:"Name of the request [header] to convey the SAML nameID/subject"`
 	AttributeHeaderMappings map[string]string `usage:"Comma separated list of [attribute=header] pairs mapping SAML IdP response attributes to forwarded request header"`
+	AttributeHeaderWildcard bool              `usage:"Maps all SAML into X-SW- headers"`
 	NewAuthWebhookUrl       string            `usage:"[URL] of webhook that will get POST'ed when a new authentication is processed"`
 	AuthorizeAttribute      string            `usage:"Enables authorization and specifies the [attribute] to check for authorized values"`
 	AuthorizeValues         []string          `usage:"If enabled, comma separated list of [values] that must be present in the authorize attribute"`

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ type Config struct {
 	SpCertPath              string            `default:"saml-auth-proxy.cert" usage:"The [path] to the X509 public certificate PEM file for this SP"`
 	NameIdMapping           string            `usage:"Name of the request [header] to convey the SAML nameID/subject"`
 	AttributeHeaderMappings map[string]string `usage:"Comma separated list of [attribute=header] pairs mapping SAML IdP response attributes to forwarded request header"`
-	AttributeHeaderWildcard bool              `usage:"Maps all SAML into X-SW- headers"`
+	AttributeHeaderWildcard bool              `usage:"Maps all SAML into X-*Saml*- headers"`
 	NewAuthWebhookUrl       string            `usage:"[URL] of webhook that will get POST'ed when a new authentication is processed"`
 	AuthorizeAttribute      string            `usage:"Enables authorization and specifies the [attribute] to check for authorized values"`
 	AuthorizeValues         []string          `usage:"If enabled, comma separated list of [values] that must be present in the authorize attribute"`

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ type Config struct {
 	SpCertPath              string            `default:"saml-auth-proxy.cert" usage:"The [path] to the X509 public certificate PEM file for this SP"`
 	NameIdMapping           string            `usage:"Name of the request [header] to convey the SAML nameID/subject"`
 	AttributeHeaderMappings map[string]string `usage:"Comma separated list of [attribute=header] pairs mapping SAML IdP response attributes to forwarded request header"`
-	AttributeHeaderWildcard bool              `usage:"Maps all SAML into X-*Saml*- headers"`
+	AttributeHeaderWildcard string            `usage:"Maps all SAML attributes with this option as a prefix`
 	NewAuthWebhookUrl       string            `usage:"[URL] of webhook that will get POST'ed when a new authentication is processed"`
 	AuthorizeAttribute      string            `usage:"Enables authorization and specifies the [attribute] to check for authorized values"`
 	AuthorizeValues         []string          `usage:"If enabled, comma separated list of [values] that must be present in the authorize attribute"`


### PR DESCRIPTION
Added an option you can set to a prefix and all saml attributes will be appended, no need to know the attribute you want, you can have them all.

Readme updated as appropriated, default behaviour unchanged. No breaking changes.