### PR TITLE
Use AddCookie method for greater compatibility

### DIFF
--- a/server/proxy.go
+++ b/server/proxy.go
@@ -106,7 +106,7 @@ func (p *proxy) handler(respOutWriter http.ResponseWriter, reqIn *http.Request) 
 	cookies := reqIn.Cookies()
 	for _, cookie := range cookies {
 		if cookie.Name != tokenCookieName {
-			reqOut.Header.Add("Cookie", cookie.String())
+			reqOut.AddCookie(cookie);
 		}
 	}
 


### PR DESCRIPTION
In b1e87735759af5bd28fc96812e77749bcc112505 cookie manipulation logic was added which results in multiple cookies split across multiple `Cookie:` headers.

Some systems cannot deal correctly with cookies presented like this. On an NGINX + PHP-FPM setup, I observed that only the _last_ cookie was available to the application!

This PR uses the AddCookie method of Request which avoids the issue:
> Per RFC 6265 section 5.4, AddCookie does not attach more than one Cookie header field.
> That means all cookies, if any, are written into the same line, separated by semicolon.

Tested with grafana example, and after change, all cookies are passed in a single header.