### PR TITLE
Support anonymous access to the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Provides a SAML SP authentication proxy for backend web services
         Optional path to a CA certificate PEM file for the IdP (env SAML_PROXY_IDP_CA_PATH)
   -idp-metadata-url URL
         URL of the IdP's metadata XML, can be a local file by specifying the file:// scheme (env SAML_PROXY_IDP_METADATA_URL)
+  -initiate-session-path path
+        If set, initiates a SAML authentication flow only when a user visits this path. This will allow anonymous users to access to the backend. (env SAML_PROXY_INITIATE_SESSION_PATH)
   -name-id-format string
         One of unspecified, transient, email, or persistent to use a standard format or give a full URN of the name ID format (env SAML_PROXY_NAME_ID_FORMAT) (default "transient")
   -idp-metadata-url URL

--- a/server/config.go
+++ b/server/config.go
@@ -26,4 +26,5 @@ type Config struct {
 	AuthVerifyPath          string            `default:"/_verify" usage:"Path under BaseUrl that will respond with a 200 when authenticated"`
 	Debug                   bool              `usage:"Enable debug logs"`
 	StaticRelayState        string            `usage:"A fixed RelayState value, such as a short URL. Will be trimmed to 80 characters to conform with SAML. The default generates random bytes that are Base64 encoded."`
+	InitiateSessionPath     string            `usage:"If set, initiates a SAML authentication flow only when a user visits this path. This will allow anonymous users to access to the backend."`
 }


### PR DESCRIPTION
Allow users to access to the backend application without authentication.

# Backgrounds / Ideas

See the issue below:

- Fix #60 

# Added configuration

```
  -initiate-session-path path
        If set, initiates a SAML authentication flow only when a user visits this path. This will allow anonymous users to access to the backend. (env SAML_PROXY_INITIATE_SESSION_PATH)
```

Example: By setting `-initiate-session-path /login`, Grafana behind saml-auth-proxy can handle `auth.anonymous` configuration. `/login` is the path which is pointed by Sign In button of Grafana.