### PR TITLE
Support anonymous access prior to login request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Run tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /*metadata.xml
-/*.cert
-/*.key
+*.cert
+*.key
 
 /dist/
 /saml-auth-proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.16 AS builder
+FROM golang:1.20-alpine3.16 AS builder
 
 WORKDIR /app
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Provides a SAML SP authentication proxy for backend web services
         Optional path to a CA certificate PEM file for the IdP (env SAML_PROXY_IDP_CA_PATH)
   -idp-metadata-url URL
         URL of the IdP's metadata XML, can be a local file by specifying the file:// scheme (env SAML_PROXY_IDP_METADATA_URL)
+  -initiate-session-path path
+        If set, initiates a SAML authentication flow only when a user visits this path. This will allow anonymous users to access to the backend. (env SAML_PROXY_INITIATE_SESSION_PATH)
   -name-id-format string
         One of unspecified, transient, email, or persistent to use a standard format or give a full URN of the name ID format (env SAML_PROXY_NAME_ID_FORMAT) (default "transient")
   -idp-metadata-url URL

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/crewjam/httperr v0.2.0 h1:b2BfXR8U3AlIHwNeFFvZ+BV1LFvKLlzMjzaTnZMybNo
 github.com/crewjam/httperr v0.2.0/go.mod h1:Jlz+Sg/XqBQhyMjdDiC+GNNRzZTD7x39Gu3pglZ5oH4=
 github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
 github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
+github.com/crewjam/saml v0.4.13 h1:TYHggH/hwP7eArqiXSJUvtOPNzQDyQ7vwmwEqlFWhMc=
+github.com/crewjam/saml v0.4.13/go.mod h1:igEejV+fihTIlHXYP8zOec3V5A8y3lws5bQBFsTm4gA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/server/anonymous.go
+++ b/server/anonymous.go
@@ -16,15 +16,15 @@ func IsAnonymousSession(session samlsp.Session) bool {
 	return isAnonymous
 }
 
+// InitAnonymousSessionProvider will initially provide AnonymousSession instances when requested; however,
+// once the given initiateSessionPath is intercepted, then remaining session access is delegated to the
+// given delegateSessionProvider.
 type InitAnonymousSessionProvider struct {
 	delegateSessionProvider samlsp.SessionProvider
 	initiateSessionPath     string
 	logger                  *zap.Logger
 }
 
-// NewInitAnonymousSessionProvider will initially provide AnonymousSession instances when requested; however,
-// once the given initiateSessionPath is intercepted, then remaining session access is delegated to the
-// given delegateSessionProvider.
 func NewInitAnonymousSessionProvider(logger *zap.Logger, initiateSessionPath string, delegateSessionProvider samlsp.SessionProvider) *InitAnonymousSessionProvider {
 	return &InitAnonymousSessionProvider{
 		delegateSessionProvider: delegateSessionProvider,

--- a/server/anonymous.go
+++ b/server/anonymous.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"errors"
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type AnonymousSession struct {
+}
+
+func IsAnonymousSession(session samlsp.Session) bool {
+	_, isAnonymous := session.(AnonymousSession)
+	return isAnonymous
+}
+
+type InitAnonymousSessionProvider struct {
+	delegateSessionProvider samlsp.SessionProvider
+	initiateSessionPath     string
+	logger                  *zap.Logger
+}
+
+// NewInitAnonymousSessionProvider will initially provide AnonymousSession instances when requested; however,
+// once the given initiateSessionPath is intercepted, then remaining session access is delegated to the
+// given delegateSessionProvider.
+func NewInitAnonymousSessionProvider(logger *zap.Logger, initiateSessionPath string, delegateSessionProvider samlsp.SessionProvider) *InitAnonymousSessionProvider {
+	return &InitAnonymousSessionProvider{
+		delegateSessionProvider: delegateSessionProvider,
+		initiateSessionPath:     initiateSessionPath,
+		logger:                  logger.With(zap.String("scope", "InitAnonymousSessionProvider")),
+	}
+}
+
+func (p *InitAnonymousSessionProvider) CreateSession(w http.ResponseWriter, r *http.Request, assertion *saml.Assertion) error {
+	return p.delegateSessionProvider.CreateSession(w, r, assertion)
+}
+
+func (p *InitAnonymousSessionProvider) DeleteSession(w http.ResponseWriter, r *http.Request) error {
+	return p.delegateSessionProvider.DeleteSession(w, r)
+}
+
+func (p *InitAnonymousSessionProvider) GetSession(r *http.Request) (samlsp.Session, error) {
+	session, err := p.delegateSessionProvider.GetSession(r)
+	if err != nil {
+		if errors.Is(err, samlsp.ErrNoSession) {
+			if r.URL.Path == p.initiateSessionPath {
+				p.logger.Debug("Intercepted initiate session path", zap.String("path", r.URL.Path))
+				return nil, samlsp.ErrNoSession
+			}
+			p.logger.Debug("Auth has not been initiated, returning anonymous session", zap.String("path", r.URL.Path))
+			return AnonymousSession{}, nil
+		} else {
+			return nil, err
+		}
+	} else {
+		return session, nil
+	}
+}

--- a/server/config.go
+++ b/server/config.go
@@ -26,4 +26,5 @@ type Config struct {
 	AuthVerifyPath          string            `default:"/_verify" usage:"Path under BaseUrl that will respond with a 200 when authenticated"`
 	Debug                   bool              `usage:"Enable debug logs"`
 	StaticRelayState        string            `usage:"A fixed RelayState value, such as a short URL. Will be trimmed to 80 characters to conform with SAML. The default generates random bytes that are Base64 encoded."`
+	InitiateSessionPath     string            `usage:"If set, initiates a SAML authentication flow only when a user visits this path. This will allow anonymous users to access to the backend."`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,12 @@ func Start(ctx context.Context, logger *zap.Logger, cfg *Config) error {
 	cookieSessionProvider.Name = cfg.CookieName
 	cookieSessionProvider.Domain = cookieDomain
 	cookieSessionProvider.MaxAge = cfg.CookieMaxAge
-	middleware.Session = cookieSessionProvider
+
+	if cfg.InitiateSessionPath != "" {
+		middleware.Session = NewInitAnonymousSessionProvider(logger, cfg.InitiateSessionPath, cookieSessionProvider)
+	} else {
+		middleware.Session = cookieSessionProvider
+	}
 
 	proxy, err := NewProxy(logger, cfg)
 	if err != nil {

--- a/test/grafana-public-dashboards/README.md
+++ b/test/grafana-public-dashboards/README.md
@@ -1,0 +1,20 @@
+
+## Setup
+
+Create the proxy's cert and key files [like in the README](../../README.md#trying-it-out)
+
+Bring up the services setting the `BASE_URL` to the publicly resolvable URL of your service:
+
+```shell
+BASE_URL=... docker compose up -d --build
+```
+
+Export and upload the IDP metadata [like in the README](../../README.md#trying-it-out)
+
+Access Grafana via the proxy at <http://localhost:8080>
+
+Login as Rick via `samltest.idp`  since the test configures that user as admin.
+
+Go to the pre-provisioned dashboard at the path `/d/c6f2205a-a683-417f-b177-b916085d5519/public?orgId=1`, [make it public](https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/#make-a-dashboard-public), and copy the public dashboard link.
+
+Open an incognito tab (or equivalent) and confirm access to the public dashboard without login. Go to some other path like `/` and confirm that you are redirected to login via SAML auth.

--- a/test/grafana-public-dashboards/dashboards/public.json
+++ b/test/grafana-public-dashboards/dashboards/public.json
@@ -1,0 +1,68 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# Welcome\n\nThis is a public dashboard",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.3",
+      "title": "Panel Title",
+      "type": "text"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Public",
+  "uid": "c6f2205a-a683-417f-b177-b916085d5519",
+  "version": 2,
+  "weekStart": ""
+}

--- a/test/grafana-public-dashboards/docker-compose.yml
+++ b/test/grafana-public-dashboards/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.4'
+
+services:
+  proxy:
+    build:
+      context: ../..
+    environment:
+      SAML_PROXY_DEBUG: true
+      SAML_PROXY_IDP_METADATA_URL: https://samltest.id/saml/idp
+      SAML_PROXY_BASE_URL: ${BASE_URL}
+#      SAML_PROXY_BACKEND_URL: http://web-debug-server:8080
+      SAML_PROXY_BACKEND_URL: http://grafana:3000
+      SAML_PROXY_SP_KEY_PATH: /run/secrets/samlsp-key
+      SAML_PROXY_SP_CERT_PATH: /run/secrets/samlsp-cert
+      SAML_PROXY_ATTRIBUTE_HEADER_MAPPINGS: uid=x-webauth-user
+      SAML_PROXY_INITIATE_SESSION_PATH: /login
+    ports:
+      - "8080:8080"
+    secrets:
+      - samlsp-key
+      - samlsp-cert
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SERVER_ROOT_URL: ${BASE_URL}
+      GF_SECURITY_ADMIN_USER: rick
+      GF_AUTH_PROXY_ENABLED: "true"
+      GF_AUTH_PROXY_HEADER_NAME: X-WEBAUTH-USER
+      GF_FEATURE_TOGGLES_ENABLE: publicDashboards
+    volumes:
+      - grafana:/var/lib/grafana
+      - ./provisioning:/etc/grafana/provisioning
+      - ./dashboards:/var/lib/grafana/dashboards:ro
+  web-debug-server:
+    image: itzg/web-debug-server:1.2.3
+    ports:
+      - "8081:8080"
+
+volumes:
+  grafana: {}
+
+secrets:
+  samlsp-key:
+    file: saml-auth-proxy.key
+  samlsp-cert:
+    file: saml-auth-proxy.cert

--- a/test/grafana-public-dashboards/provisioning/dashboards/files.yml
+++ b/test/grafana-public-dashboards/provisioning/dashboards/files.yml
@@ -1,0 +1,24 @@
+apiVersion: 1
+
+providers:
+  # <string> an unique provider name. Required
+  - name: 'files'
+    # <int> Org id. Default to 1
+    orgId: 1
+    # <string> name of the dashboard folder.
+    folder: ''
+    # <string> folder UID. will be automatically generated if not specified
+    folderUid: ''
+    # <string> provider type. Default to 'file'
+    type: file
+    # <bool> disable dashboard deletion
+    disableDeletion: false
+    # <int> how often Grafana will scan for changed dashboards
+    updateIntervalSeconds: 10
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: false
+    options:
+      # <string, required> path to dashboard files on disk. Required when using the 'file' type
+      path: /var/lib/grafana/dashboards
+      # <bool> use folder names from filesystem to create folders in Grafana
+      foldersFromFilesStructure: true


### PR DESCRIPTION
Resolves #60 

Leverages the ideas in https://github.com/itzg/saml-auth-proxy/pull/62 but introduces a new session provider that return "anonymous" sessions until the initiate session path is intercepted.

Also upgrades to Go 1.20

cc @kyori19 
