### PR TITLE
Support for custom EntityID

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides a SAML SP authentication proxy for backend web services
   -attribute-header-mappings attribute=header
         Comma separated list of attribute=header pairs mapping SAML IdP response attributes to forwarded request header (env SAML_PROXY_ATTRIBUTE_HEADER_MAPPINGS)
   -attribute-header-wildcard string
-         (env SAML_PROXY_ATTRIBUTE_HEADER_WILDCARD)
+        Maps all SAML attributes with this option as a prefix, slashes in attribute names will be replaced by dashes (env SAML_PROXY_ATTRIBUTE_HEADER_WILDCARD)
   -auth-verify bool
         Enables verify path endpoint for forward auth and trusts X-Forwarded headers (env SAML_PROXY_AUTH_VERIFY)
   -auth-verify-path string
@@ -33,6 +33,8 @@ Provides a SAML SP authentication proxy for backend web services
         Specifies the amount of time the authentication token will remain valid (env SAML_PROXY_COOKIE_MAX_AGE) (default 2h0m0s) 
   -cookie-name string
         Name of the cookie that tracks session token (env SAML_PROXY_COOKIE_NAME) (default "token")
+  -entity-id string
+        Entity ID of this service provider (env SAML_PROXY_ENTITY_ID)
   -idp-ca-path path
         Optional path to a CA certificate PEM file for the IdP (env SAML_PROXY_IDP_CA_PATH)
   -idp-metadata-url URL

--- a/server/config.go
+++ b/server/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	Bind                    string            `default:":8080" usage:"[host:port] to bind for serving HTTP"`
 	BaseUrl                 string            `usage:"External [URL] of this proxy"`
 	BackendUrl              string            `usage:"[URL] of the backend being proxied"`
+	EntityID                string            `usage:"Entity ID of this service provider"`
 	IdpMetadataUrl          string            `usage:"[URL] of the IdP's metadata XML, can be a local file by specifying the file:// scheme"`
 	IdpCaPath               string            `usage:"Optional [path] to a CA certificate PEM file for the IdP"`
 	NameIdFormat            string            `usage:"One of unspecified, transient, email, or persistent to use a standard format or give a full URN of the name ID format" default:"transient"`
@@ -14,7 +15,7 @@ type Config struct {
 	SpCertPath              string            `default:"saml-auth-proxy.cert" usage:"The [path] to the X509 public certificate PEM file for this SP"`
 	NameIdMapping           string            `usage:"Name of the request [header] to convey the SAML nameID/subject"`
 	AttributeHeaderMappings map[string]string `usage:"Comma separated list of [attribute=header] pairs mapping SAML IdP response attributes to forwarded request header"`
-	AttributeHeaderWildcard string            `usage:"Maps all SAML attributes with this option as a prefix"`
+	AttributeHeaderWildcard string            `usage:"Maps all SAML attributes with this option as a prefix, slashes in attribute names will be replaced by dashes"`
 	NewAuthWebhookUrl       string            `usage:"[URL] of webhook that will get POST'ed when a new authentication is processed"`
 	AuthorizeAttribute      string            `usage:"Enables authorization and specifies the [attribute] to check for authorized values"`
 	AuthorizeValues         []string          `usage:"If enabled, comma separated list of [values] that must be present in the authorize attribute"`

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -208,6 +208,9 @@ func (p *Proxy) addHeaders(sessionClaims samlsp.JWTSessionClaims, headers http.H
 	if p.config.AttributeHeaderWildcard != "" {
 		for attr, values := range sessionClaims.GetAttributes() {
 			for _, value := range values {
+				if uri, err := url.Parse(attr); err == nil {
+					attr = strings.Trim(strings.Replace(uri.Path, "/", "-", -1), "-")
+				}
 				headers.Add(p.config.AttributeHeaderWildcard+attr, value)
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -52,6 +52,9 @@ func Start(ctx context.Context, logger *zap.Logger, cfg *Config) error {
 		Certificate:       keyPair.Leaf,
 		AllowIDPInitiated: cfg.AllowIdpInitiated,
 	}
+	if cfg.EntityID != "" {
+		samlOpts.EntityID = cfg.EntityID
+	}
 
 	samlOpts.IDPMetadata, err = fetchMetadata(ctx, httpClient, idpMetadataUrl)
 	if err != nil {


### PR DESCRIPTION
## Add support for EntityID SAML option

Azure implementation forces you to use an specific `EntityID` SAML option with the format of `"spn:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"`. This PR added this functionality.

For the other hand, when using `AttributeHeaderWildcard`, session claims can contain slashes (`/`). In that case, this PR will  replace slashes `/` by hypens `-`. I'm not sure about this strategy, so I'm open to change if needed.