### PR TITLE
Adds support for SAML request signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Provides a SAML SP authentication proxy for backend web services
         Name of the request header to convey the SAML nameID/subject (env SAML_PROXY_NAME_ID_MAPPING)
   -new-auth-webhook-url URL
         URL of webhook that will get POST'ed when a new authentication is processed (env SAML_PROXY_NEW_AUTH_WEBHOOK_URL)
+  -sign-requests
+        If set, enables SAML request signing (env SAML_PROXY_SIGN_REQUESTS)
   -sp-cert-path path
         The path to the X509 public certificate PEM file for this SP (env SAML_PROXY_SP_CERT_PATH) (default "saml-auth-proxy.cert")
   -sp-key-path path

--- a/server/config.go
+++ b/server/config.go
@@ -28,4 +28,5 @@ type Config struct {
 	Debug                   bool              `usage:"Enable debug logs"`
 	StaticRelayState        string            `usage:"A fixed RelayState value, such as a short URL. Will be trimmed to 80 characters to conform with SAML. The default generates random bytes that are Base64 encoded."`
 	InitiateSessionPath     string            `usage:"If set, initiates a SAML authentication flow only when a user visits this path. This will allow anonymous users to access to the backend."`
+	SignRequests            bool              `usage:"If set, enables SAML request signing"`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -51,6 +51,7 @@ func Start(ctx context.Context, logger *zap.Logger, cfg *Config) error {
 		Key:               keyPair.PrivateKey.(*rsa.PrivateKey),
 		Certificate:       keyPair.Leaf,
 		AllowIDPInitiated: cfg.AllowIdpInitiated,
+		SignRequest:       cfg.SignRequests,
 	}
 	if cfg.EntityID != "" {
 		samlOpts.EntityID = cfg.EntityID


### PR DESCRIPTION
This PR addresses issue #80. It adds a new CLI flag, `sign-requests`, that enables SAML request signing. This fixes an issue for us when integrating with an IdP that requires/supports signed requests.