### PR TITLE
build: upgrade to Go 1.22.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
+    with:
+      go-version: "1.22.5"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,5 @@ on:
 jobs:
   test:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
+    with:
+      go-version: "1.22.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.20-alpine3.16 AS builder
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /app
 COPY . /app
 RUN go build
 
 
-FROM alpine:3.16
+FROM alpine
 
 RUN apk add --no-cache -U \
   ca-certificates


### PR DESCRIPTION
Resolves vulnerabilities:
- GO-2024-2963
- GO-2024-2887
- GO-2024-2824
