### PR TITLE
Moved auth_verify to server, returning 204 or 401 as per nginx standards

### DIFF
--- a/server/proxy.go
+++ b/server/proxy.go
@@ -99,15 +99,6 @@ func (p *Proxy) handler(respOutWriter http.ResponseWriter, reqIn *http.Request) 
 			return
 		}
 
-		if p.config.AuthVerify && reqIn.URL.Path == p.config.AuthVerifyPath {
-			p.logger.
-				With(zap.String("remoteAddr", reqIn.RemoteAddr)).
-				Debug("Responding with 204 to auth verify request")
-			p.addHeaders(sessionClaims, respOutWriter.Header())
-			respOutWriter.WriteHeader(204)
-			return
-		}
-
 		reqOut = p.setupRequest(respOutWriter, reqIn)
 		if reqOut == nil {
 			return


### PR DESCRIPTION
With the current proxy mode, saml-auth-proxy cannot be used for only verification purposes.

This change follows the functionality seen on oauth2-proxy, exposing a verify only endpoint which either returns `204 Accepted` or `401 Forbidden`.

This should work for nginx, traefik and Caddy.