### PR TITLE
Add unix socket listening support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/itzg/zapconfigs v0.1.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.1.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
 	"github.com/itzg/go-flagsfiller"
 	"github.com/itzg/saml-auth-proxy/server"
 	"github.com/itzg/zapconfigs"
 	"go.uber.org/zap"
-	"log"
-	"os"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -45,10 +51,36 @@ func main() {
 	checkRequired(serverConfig.BackendUrl, "backend-url")
 	checkRequired(serverConfig.IdpMetadataUrl, "idp-metadata-url")
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
-	// server only returns when there's an error
-	log.Fatal(server.Start(ctx, logger, &serverConfig))
+	go func() {
+		c := make(chan os.Signal, 1) // we need to reserve to buffer size 1, so the notifier are not blocked
+		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+		<-c
+		cancel()
+	}()
+
+	var bindType, bind = httpBinding(serverConfig.Bind)
+
+	listener, err := net.Listen(bindType, bind)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return server.Start(ctx, listener, logger, &serverConfig)
+	})
+
+	g.Go(func() error {
+		<-gCtx.Done()
+		return listener.Close()
+	})
+
+	if err := g.Wait(); err != nil {
+		fmt.Printf("exit reason: %s \n", err)
+	}
 }
 
 func checkRequired(value string, name string) {
@@ -57,4 +89,14 @@ func checkRequired(value string, name string) {
 		flag.Usage()
 		os.Exit(2)
 	}
+}
+
+func httpBinding(bind string) (string, string) {
+
+	if strings.HasPrefix(bind, "unix:") {
+		return "unix", strings.TrimLeft(bind, "unix:")
+	} else {
+		return "tcp", bind
+	}
+
 }


### PR DESCRIPTION
This adds support for saml-auth-proxy to listen on a unix socket instead of TCP port.

If `SAML_PROXY_BIND` has a format of `unix:/var/run/saml-auth-proxy.sock`, a unix socket will be created instead.

Because unix sockets require a clean shutdown of the network connection (`listener.close`), this also adds a [errgroup](https://pkg.go.dev/golang.org/x/sync/errgroup) wrapper to clean up on shutdown.