### PR TITLE
fix: corrects JWE and JWT session codecs init

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Provides a SAML SP authentication proxy for backend web services
   -sign-requests
         If set, enables SAML request signing (env SAML_PROXY_SIGN_REQUESTS)
   -encrypt-jwt
-        If set, JWTs will be encrypted as JWE (env SAML_ENCRYPT_JWT)
+        If set, JWTs will be encrypted as JWE (env SAML_PROXY_ENCRYPT_JWT)
   -sp-cert-path path
         The path to the X509 public certificate PEM file for this SP (env SAML_PROXY_SP_CERT_PATH) (default "saml-auth-proxy.cert")
   -sp-key-path path

--- a/server/server.go
+++ b/server/server.go
@@ -99,16 +99,12 @@ func Start(ctx context.Context, listener net.Listener, logger *zap.Logger, cfg *
 	cookieSessionProvider.Name = cfg.CookieName
 	cookieSessionProvider.Domain = cookieDomain
 	cookieSessionProvider.MaxAge = cfg.CookieMaxAge
-
-	// default session provider uses JWT, so we can safely cast it
-	jwtSessionCodec, ok := cookieSessionProvider.Codec.(*samlsp.JWTSessionCodec)
-	if !ok {
-		return fmt.Errorf("session provider codec isn't a JWT session codec")
-	}
-	jwtSessionCodec.MaxAge = cfg.CookieMaxAge
+	codec := samlsp.DefaultSessionCodec(samlOpts)
+	codec.MaxAge = cfg.CookieMaxAge
+	cookieSessionProvider.Codec = codec
 
 	if cfg.EncryptJWT {
-		jweSessionCodec, err := NewJWESessionCodec(jwtSessionCodec)
+		jweSessionCodec, err := NewJWESessionCodec(cookieSessionProvider.Codec)
 		if err != nil {
 			return fmt.Errorf("failed to create jwe session codec: %w", err)
 		}

--- a/server/session_jwe.go
+++ b/server/session_jwe.go
@@ -16,7 +16,12 @@ type JWESessionCodec struct {
 	privateKey      *rsa.PrivateKey
 }
 
-func NewJWESessionCodec(codec *samlsp.JWTSessionCodec) (samlsp.SessionCodec, error) {
+func NewJWESessionCodec(sessionCodec samlsp.SessionCodec) (samlsp.SessionCodec, error) {
+	codec, ok := sessionCodec.(samlsp.JWTSessionCodec)
+	if !ok {
+		return nil, fmt.Errorf("session codec isn't JWT session codec")
+	}
+
 	// get the public and private key from the underlying codec to use for encryption
 	publicKey := &codec.Key.PublicKey
 	privateKey := codec.Key
@@ -27,7 +32,7 @@ func NewJWESessionCodec(codec *samlsp.JWTSessionCodec) (samlsp.SessionCodec, err
 		return nil, fmt.Errorf("failed to create jwe encrypter: %w", err)
 	}
 
-	return &JWESessionCodec{jwtSessionCodec: codec, encrypter: encrypter, privateKey: privateKey}, nil
+	return &JWESessionCodec{jwtSessionCodec: &codec, encrypter: encrypter, privateKey: privateKey}, nil
 }
 
 func (c *JWESessionCodec) New(assertion *saml.Assertion) (samlsp.Session, error) {

--- a/server/session_jwe_test.go
+++ b/server/session_jwe_test.go
@@ -24,7 +24,7 @@ func TestJWESessionCodec(t *testing.T) {
 	jwtCodec := samlsp.DefaultSessionCodec(samlsp.Options{Key: key, URL: *baseURL})
 
 	// Create the JWESessionCodec
-	jweCodec, err := NewJWESessionCodec(&jwtCodec)
+	jweCodec, err := NewJWESessionCodec(jwtCodec)
 	if err != nil {
 		t.Fatalf("failed to create JWESessionCodec: %v", err)
 	}


### PR DESCRIPTION
Sorry Geoff,

This should fix it. Verified the max age in my tests too.

I wanted to write a test for server.go, but it's difficult to verify the samlsp.Middleware instance without refactoring.