### PR TITLE
fix: requires auth to forward auth handler (AuthVerify config)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -124,7 +124,7 @@ func Start(ctx context.Context, listener net.Listener, logger *zap.Logger, cfg *
 
 	app := http.HandlerFunc(proxy.handler)
 	if cfg.AuthVerify {
-		http.Handle(cfg.AuthVerifyPath, middleware.RequireAccount(authVerify(middleware)))
+		http.Handle(cfg.AuthVerifyPath, middleware.RequireAccount(http.HandlerFunc(noContentHandler)))
 	}
 
 	http.Handle("/saml/sign_in", http.HandlerFunc(middleware.HandleStartAuthFlow))
@@ -187,8 +187,7 @@ func setupHttpClient(idpCaFile string) (*http.Client, error) {
 	return client, nil
 }
 
-func authVerify(middleware *samlsp.Middleware) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(204)
-	})
+// HTTP handler that replies to each request with a “204 no content”.
+func noContentHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
Fixes #105 

The forward auth endpoint correctly returns 2xx status code for authenticated requests. However, it returns 401 instead of triggering login from saml.

Changes:
- adds RequreAccount middleware to auth verify path endpoint