### PR TITLE
Add nginx auth_request support

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	AllowIdpInitiated       bool              `usage:"If set, allows for IdP initiated authentication flow"`
 	AuthVerify              bool              `usage:"Enables verify path endpoint for forward auth and trusts X-Forwarded headers"`
 	AuthVerifyPath          string            `default:"/_verify" usage:"Path under BaseUrl that will respond with a 200 when authenticated"`
+	AuthVerifyRequireLogin  bool              `usage:"If set, trigger a login if the user is not authenticated during verify"`
 	Debug                   bool              `usage:"Enable debug logs"`
 	StaticRelayState        string            `usage:"A fixed RelayState value, such as a short URL. Will be trimmed to 80 characters to conform with SAML. The default generates random bytes that are Base64 encoded."`
 	InitiateSessionPath     string            `usage:"If set, initiates a SAML authentication flow only when a user visits this path. This will allow anonymous users to access to the backend."`

--- a/server/server.go
+++ b/server/server.go
@@ -124,7 +124,11 @@ func Start(ctx context.Context, listener net.Listener, logger *zap.Logger, cfg *
 
 	app := http.HandlerFunc(proxy.handler)
 	if cfg.AuthVerify {
-		http.Handle(cfg.AuthVerifyPath, authVerify(middleware))
+		if cfg.AuthVerifyRequireLogin {
+			http.Handle(cfg.AuthVerifyPath, middleware.RequireAccount(http.HandlerFunc(noContentHandler)))
+		} else {
+			http.Handle(cfg.AuthVerifyPath, authVerify(middleware))
+		}
 	}
 
 	http.Handle("/saml/sign_in", http.HandlerFunc(middleware.HandleStartAuthFlow))
@@ -185,6 +189,11 @@ func setupHttpClient(idpCaFile string) (*http.Client, error) {
 	client := &http.Client{Transport: tr}
 
 	return client, nil
+}
+
+// HTTP handler that replies to each request with a “204 no content”.
+func noContentHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func authVerify(middleware *samlsp.Middleware) http.Handler {


### PR DESCRIPTION
nginx [auth_request](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/) requires either a 2xx (authenticated) or 401/403 (authentication required) response.

This updates saml-auth-proxy to respond appropriately to nginx auth_requests.

The authentication check is identical to the [middleware.RequireAccount](https://github.com/crewjam/saml/blob/346540312f721498fc75e69637d9250dd89f230b/samlsp/middleware.go#L115) function. 
middleware.RequireAccount cannot be used directly because it starts the authentication flow if not authentication, which nginx auth_request does not expect.
